### PR TITLE
aya,aya-obj: conversion for u32 to prog type enum & format enum display

### DIFF
--- a/aya-obj/src/programs/mod.rs
+++ b/aya-obj/src/programs/mod.rs
@@ -3,6 +3,7 @@
 pub mod cgroup_sock;
 pub mod cgroup_sock_addr;
 pub mod cgroup_sockopt;
+pub mod prog_type;
 pub mod xdp;
 
 pub use cgroup_sock::CgroupSockAttachType;

--- a/aya-obj/src/programs/prog_type.rs
+++ b/aya-obj/src/programs/prog_type.rs
@@ -1,0 +1,102 @@
+//! Program type bindings.
+
+use core::fmt::Display;
+
+use crate::generated::bpf_prog_type::{self, *};
+
+/// Invalid program type encountered
+pub struct InvalidProgramTypeError {
+    /// The program type
+    pub prog_type: u32,
+}
+
+impl TryFrom<u32> for bpf_prog_type {
+    type Error = InvalidProgramTypeError;
+
+    fn try_from(prog_type: u32) -> Result<Self, Self::Error> {
+        Ok(match prog_type {
+            x if x == BPF_PROG_TYPE_UNSPEC as u32 => BPF_PROG_TYPE_UNSPEC,
+            x if x == BPF_PROG_TYPE_SOCKET_FILTER as u32 => BPF_PROG_TYPE_SOCKET_FILTER,
+            x if x == BPF_PROG_TYPE_KPROBE as u32 => BPF_PROG_TYPE_KPROBE,
+            x if x == BPF_PROG_TYPE_SCHED_CLS as u32 => BPF_PROG_TYPE_SCHED_CLS,
+            x if x == BPF_PROG_TYPE_SCHED_ACT as u32 => BPF_PROG_TYPE_SCHED_ACT,
+            x if x == BPF_PROG_TYPE_TRACEPOINT as u32 => BPF_PROG_TYPE_TRACEPOINT,
+            x if x == BPF_PROG_TYPE_XDP as u32 => BPF_PROG_TYPE_XDP,
+            x if x == BPF_PROG_TYPE_PERF_EVENT as u32 => BPF_PROG_TYPE_PERF_EVENT,
+            x if x == BPF_PROG_TYPE_CGROUP_SKB as u32 => BPF_PROG_TYPE_CGROUP_SKB,
+            x if x == BPF_PROG_TYPE_CGROUP_SOCK as u32 => BPF_PROG_TYPE_CGROUP_SOCK,
+            x if x == BPF_PROG_TYPE_LWT_IN as u32 => BPF_PROG_TYPE_LWT_IN,
+            x if x == BPF_PROG_TYPE_LWT_OUT as u32 => BPF_PROG_TYPE_LWT_OUT,
+            x if x == BPF_PROG_TYPE_LWT_XMIT as u32 => BPF_PROG_TYPE_LWT_XMIT,
+            x if x == BPF_PROG_TYPE_SOCK_OPS as u32 => BPF_PROG_TYPE_SOCK_OPS,
+            x if x == BPF_PROG_TYPE_SK_SKB as u32 => BPF_PROG_TYPE_SK_SKB,
+            x if x == BPF_PROG_TYPE_CGROUP_DEVICE as u32 => BPF_PROG_TYPE_CGROUP_DEVICE,
+            x if x == BPF_PROG_TYPE_SK_MSG as u32 => BPF_PROG_TYPE_SK_MSG,
+            x if x == BPF_PROG_TYPE_RAW_TRACEPOINT as u32 => BPF_PROG_TYPE_RAW_TRACEPOINT,
+            x if x == BPF_PROG_TYPE_CGROUP_SOCK_ADDR as u32 => BPF_PROG_TYPE_CGROUP_SOCK_ADDR,
+            x if x == BPF_PROG_TYPE_LWT_SEG6LOCAL as u32 => BPF_PROG_TYPE_LWT_SEG6LOCAL,
+            x if x == BPF_PROG_TYPE_LIRC_MODE2 as u32 => BPF_PROG_TYPE_LIRC_MODE2,
+            x if x == BPF_PROG_TYPE_SK_REUSEPORT as u32 => BPF_PROG_TYPE_SK_REUSEPORT,
+            x if x == BPF_PROG_TYPE_FLOW_DISSECTOR as u32 => BPF_PROG_TYPE_FLOW_DISSECTOR,
+            x if x == BPF_PROG_TYPE_CGROUP_SYSCTL as u32 => BPF_PROG_TYPE_CGROUP_SYSCTL,
+            x if x == BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE as u32 => {
+                BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE
+            }
+            x if x == BPF_PROG_TYPE_CGROUP_SOCKOPT as u32 => BPF_PROG_TYPE_CGROUP_SOCKOPT,
+            x if x == BPF_PROG_TYPE_TRACING as u32 => BPF_PROG_TYPE_TRACING,
+            x if x == BPF_PROG_TYPE_STRUCT_OPS as u32 => BPF_PROG_TYPE_STRUCT_OPS,
+            x if x == BPF_PROG_TYPE_EXT as u32 => BPF_PROG_TYPE_EXT,
+            x if x == BPF_PROG_TYPE_LSM as u32 => BPF_PROG_TYPE_LSM,
+            x if x == BPF_PROG_TYPE_SK_LOOKUP as u32 => BPF_PROG_TYPE_SK_LOOKUP,
+            x if x == BPF_PROG_TYPE_SYSCALL as u32 => BPF_PROG_TYPE_SYSCALL,
+            x if x == BPF_PROG_TYPE_NETFILTER as u32 => BPF_PROG_TYPE_NETFILTER,
+            x if x == __MAX_BPF_PROG_TYPE as u32 => __MAX_BPF_PROG_TYPE,
+            _ => return Err(InvalidProgramTypeError { prog_type }),
+        })
+    }
+}
+
+impl Display for bpf_prog_type {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        write!(
+            f,
+            "{}",
+            match self {
+                BPF_PROG_TYPE_UNSPEC => "Unspec",
+                BPF_PROG_TYPE_SOCKET_FILTER => "SocketFilter",
+                BPF_PROG_TYPE_KPROBE => "KProbe",
+                BPF_PROG_TYPE_SCHED_CLS => "SchedCls",
+                BPF_PROG_TYPE_SCHED_ACT => "SchedAct",
+                BPF_PROG_TYPE_TRACEPOINT => "TracePoint",
+                BPF_PROG_TYPE_XDP => "Xdp",
+                BPF_PROG_TYPE_PERF_EVENT => "PerfEvent",
+                BPF_PROG_TYPE_CGROUP_SKB => "CgroupSkb",
+                BPF_PROG_TYPE_CGROUP_SOCK => "CgroupSock",
+                BPF_PROG_TYPE_LWT_IN => "LwtIn",
+                BPF_PROG_TYPE_LWT_OUT => "LwtOut",
+                BPF_PROG_TYPE_LWT_XMIT => "LwtXmit",
+                BPF_PROG_TYPE_SOCK_OPS => "SockOps",
+                BPF_PROG_TYPE_SK_SKB => "SkSkb",
+                BPF_PROG_TYPE_CGROUP_DEVICE => "CgroupDevice",
+                BPF_PROG_TYPE_SK_MSG => "SkMsg",
+                BPF_PROG_TYPE_RAW_TRACEPOINT => "RawTracePoint",
+                BPF_PROG_TYPE_CGROUP_SOCK_ADDR => "CgroupSockAddr",
+                BPF_PROG_TYPE_LWT_SEG6LOCAL => "LwtSeg6local",
+                BPF_PROG_TYPE_LIRC_MODE2 => "LircMode2",
+                BPF_PROG_TYPE_SK_REUSEPORT => "SkReusePort",
+                BPF_PROG_TYPE_FLOW_DISSECTOR => "FlowDissector",
+                BPF_PROG_TYPE_CGROUP_SYSCTL => "CgroupSysctl",
+                BPF_PROG_TYPE_RAW_TRACEPOINT_WRITABLE => "RawTracePointWritable",
+                BPF_PROG_TYPE_CGROUP_SOCKOPT => "CgroupSockOpt",
+                BPF_PROG_TYPE_TRACING => "Tracing",
+                BPF_PROG_TYPE_STRUCT_OPS => "StructOps",
+                BPF_PROG_TYPE_EXT => "Ext",
+                BPF_PROG_TYPE_LSM => "Lsm",
+                BPF_PROG_TYPE_SK_LOOKUP => "SkLookup",
+                BPF_PROG_TYPE_SYSCALL => "Syscall",
+                BPF_PROG_TYPE_NETFILTER => "Netfilter",
+                __MAX_BPF_PROG_TYPE => "MaxProgType",
+            }
+        )
+    }
+}

--- a/aya/src/programs/mod.rs
+++ b/aya/src/programs/mod.rs
@@ -1039,6 +1039,12 @@ impl ProgramInfo {
         self.0.type_
     }
 
+    /// The program type as the linux kernel enum
+    /// [`bpf_prog_type`](https://elixir.bootlin.com/linux/v6.4.4/source/include/uapi/linux/bpf.h#L948).
+    pub fn program_type_enum(&self) -> Result<bpf_prog_type, ProgramError> {
+        bpf_prog_type::try_from(self.0.type_).map_err(|_| ProgramError::UnexpectedProgramType)
+    }
+
     /// Returns true if the program is defined with a GPL-compatible license.
     pub fn gpl_compatible(&self) -> bool {
         self.0.gpl_compatible() != 0

--- a/xtask/public-api/aya-obj.txt
+++ b/xtask/public-api/aya-obj.txt
@@ -1675,7 +1675,12 @@ pub fn aya_obj::generated::bpf_prog_type::clone(&self) -> aya_obj::generated::bp
 impl core::cmp::Eq for aya_obj::generated::bpf_prog_type
 impl core::cmp::PartialEq for aya_obj::generated::bpf_prog_type
 pub fn aya_obj::generated::bpf_prog_type::eq(&self, other: &aya_obj::generated::bpf_prog_type) -> bool
+impl core::convert::TryFrom<u32> for aya_obj::generated::bpf_prog_type
+pub type aya_obj::generated::bpf_prog_type::Error = aya_obj::programs::prog_type::InvalidProgramTypeError
+pub fn aya_obj::generated::bpf_prog_type::try_from(prog_type: u32) -> core::result::Result<Self, Self::Error>
 impl core::fmt::Debug for aya_obj::generated::bpf_prog_type
+pub fn aya_obj::generated::bpf_prog_type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
+impl core::fmt::Display for aya_obj::generated::bpf_prog_type
 pub fn aya_obj::generated::bpf_prog_type::fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result
 impl core::hash::Hash for aya_obj::generated::bpf_prog_type
 pub fn aya_obj::generated::bpf_prog_type::hash<__H: core::hash::Hasher>(&self, state: &mut __H)
@@ -1699,6 +1704,8 @@ impl<T> alloc::borrow::ToOwned for aya_obj::generated::bpf_prog_type where T: co
 pub type aya_obj::generated::bpf_prog_type::Owned = T
 pub fn aya_obj::generated::bpf_prog_type::clone_into(&self, target: &mut T)
 pub fn aya_obj::generated::bpf_prog_type::to_owned(&self) -> T
+impl<T> alloc::string::ToString for aya_obj::generated::bpf_prog_type where T: core::fmt::Display + core::marker::Sized
+pub fn aya_obj::generated::bpf_prog_type::to_string(&self) -> alloc::string::String
 impl<T> core::any::Any for aya_obj::generated::bpf_prog_type where T: 'static + core::marker::Sized
 pub fn aya_obj::generated::bpf_prog_type::type_id(&self) -> core::any::TypeId
 impl<T> core::borrow::Borrow<T> for aya_obj::generated::bpf_prog_type where T: core::marker::Sized
@@ -7092,6 +7099,31 @@ impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::cgroup_sockopt::Cgroup
 pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::borrow_mut(&mut self) -> &mut T
 impl<T> core::convert::From<T> for aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType
 pub fn aya_obj::programs::cgroup_sockopt::CgroupSockoptAttachType::from(t: T) -> T
+pub mod aya_obj::programs::prog_type
+pub struct aya_obj::programs::prog_type::InvalidProgramTypeError
+pub aya_obj::programs::prog_type::InvalidProgramTypeError::prog_type: u32
+impl core::marker::Freeze for aya_obj::programs::prog_type::InvalidProgramTypeError
+impl core::marker::Send for aya_obj::programs::prog_type::InvalidProgramTypeError
+impl core::marker::Sync for aya_obj::programs::prog_type::InvalidProgramTypeError
+impl core::marker::Unpin for aya_obj::programs::prog_type::InvalidProgramTypeError
+impl core::panic::unwind_safe::RefUnwindSafe for aya_obj::programs::prog_type::InvalidProgramTypeError
+impl core::panic::unwind_safe::UnwindSafe for aya_obj::programs::prog_type::InvalidProgramTypeError
+impl<T, U> core::convert::Into<U> for aya_obj::programs::prog_type::InvalidProgramTypeError where U: core::convert::From<T>
+pub fn aya_obj::programs::prog_type::InvalidProgramTypeError::into(self) -> U
+impl<T, U> core::convert::TryFrom<U> for aya_obj::programs::prog_type::InvalidProgramTypeError where U: core::convert::Into<T>
+pub type aya_obj::programs::prog_type::InvalidProgramTypeError::Error = core::convert::Infallible
+pub fn aya_obj::programs::prog_type::InvalidProgramTypeError::try_from(value: U) -> core::result::Result<T, <T as core::convert::TryFrom<U>>::Error>
+impl<T, U> core::convert::TryInto<U> for aya_obj::programs::prog_type::InvalidProgramTypeError where U: core::convert::TryFrom<T>
+pub type aya_obj::programs::prog_type::InvalidProgramTypeError::Error = <U as core::convert::TryFrom<T>>::Error
+pub fn aya_obj::programs::prog_type::InvalidProgramTypeError::try_into(self) -> core::result::Result<U, <U as core::convert::TryFrom<T>>::Error>
+impl<T> core::any::Any for aya_obj::programs::prog_type::InvalidProgramTypeError where T: 'static + core::marker::Sized
+pub fn aya_obj::programs::prog_type::InvalidProgramTypeError::type_id(&self) -> core::any::TypeId
+impl<T> core::borrow::Borrow<T> for aya_obj::programs::prog_type::InvalidProgramTypeError where T: core::marker::Sized
+pub fn aya_obj::programs::prog_type::InvalidProgramTypeError::borrow(&self) -> &T
+impl<T> core::borrow::BorrowMut<T> for aya_obj::programs::prog_type::InvalidProgramTypeError where T: core::marker::Sized
+pub fn aya_obj::programs::prog_type::InvalidProgramTypeError::borrow_mut(&mut self) -> &mut T
+impl<T> core::convert::From<T> for aya_obj::programs::prog_type::InvalidProgramTypeError
+pub fn aya_obj::programs::prog_type::InvalidProgramTypeError::from(t: T) -> T
 pub mod aya_obj::programs::xdp
 pub enum aya_obj::programs::xdp::XdpAttachType
 pub aya_obj::programs::xdp::XdpAttachType::CpuMap

--- a/xtask/public-api/aya.txt
+++ b/xtask/public-api/aya.txt
@@ -7882,6 +7882,7 @@ pub fn aya::programs::ProgramInfo::memory_locked(&self) -> core::result::Result<
 pub fn aya::programs::ProgramInfo::name(&self) -> &[u8]
 pub fn aya::programs::ProgramInfo::name_as_str(&self) -> core::option::Option<&str>
 pub fn aya::programs::ProgramInfo::program_type(&self) -> u32
+pub fn aya::programs::ProgramInfo::program_type_enum(&self) -> core::result::Result<aya_obj::generated::linux_bindings_x86_64::bpf_prog_type, aya::programs::ProgramError>
 pub fn aya::programs::ProgramInfo::run_cnt(&self) -> u64
 pub fn aya::programs::ProgramInfo::run_time_ns(&self) -> u64
 pub fn aya::programs::ProgramInfo::size_jitted(&self) -> u32


### PR DESCRIPTION
This adds conversion method from u32 to `bpf_prog_type` so that the `type_` field in `bpf_prog_info` can map to the program type enum. This also implements Display for `bpf_prog_type` for condensed output format.